### PR TITLE
Create standard interfaces for certificate methods

### DIFF
--- a/pkg/ejbca/ca_models.go
+++ b/pkg/ejbca/ca_models.go
@@ -13,8 +13,8 @@ type CertificateAuthorities struct {
 }
 
 type LatestCRL struct {
-	CRL            []string `json:"crl,omitempty"`
-	ResponseFormat string   `json:"response_format,omitempty"`
+	CRL            string `json:"crl,omitempty"`
+	ResponseFormat string `json:"response_format,omitempty"`
 }
 
 type V1CARestResourceStatus struct {

--- a/pkg/ejbca/ca_test.go
+++ b/pkg/ejbca/ca_test.go
@@ -2,18 +2,56 @@ package ejbca
 
 import "testing"
 
-func TestClient_GetCACertificatePEM(t *testing.T) {
+func TestClient_GetCACertificate(t *testing.T) {
 	ejbcaTestPreCheck(t)
+
+	cAs, err := client.GetEJBCACAList()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	certificate, err := client.GetCACertificate(cAs.CertificateAuthorities[0].SubjectDn)
+	if err != nil {
+		return
+	}
+
+	t.Logf("CA certificate with subject DN %s has thumbprint %d", cAs.CertificateAuthorities[0].SubjectDn, certificate[0].SerialNumber)
 }
 
 func TestClient_GetCRLByIssuerDn(t *testing.T) {
 	ejbcaTestPreCheck(t)
+
+	cAs, err := client.GetEJBCACAList()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	crl, err := client.GetCRLByIssuerDn(cAs.CertificateAuthorities[0].IssuerDn)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("%s's CRL: %v", cAs.CertificateAuthorities[0].IssuerDn, crl.CRL)
 }
 
 func TestClient_GetV1CAStatus(t *testing.T) {
 	ejbcaTestPreCheck(t)
+
+	status, err := client.GetV1CAStatus()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("V1 CA endpoint has status %s, version %s, and revision %s", status.Status, status.Version, status.Revision)
 }
 
 func TestClient_GetEJBCACAList(t *testing.T) {
 	ejbcaTestPreCheck(t)
+
+	list, err := client.GetEJBCACAList()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("Found %d CAs", len(list.CertificateAuthorities))
 }

--- a/pkg/ejbca/client_test.go
+++ b/pkg/ejbca/client_test.go
@@ -1,15 +1,16 @@
 package ejbca
 
 import (
-	"log"
 	"math/rand"
 	"os"
 	"testing"
+	"time"
 )
 
 var client *Client
 
 func ejbcaTestPreCheck(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
 	if client == nil {
 		config := &Config{
 			CertificateFile: os.Getenv("EJBCA_CERTPATH"),
@@ -21,11 +22,11 @@ func ejbcaTestPreCheck(t *testing.T) {
 		factory := ClientFactory(os.Getenv("EJBCA_HOSTNAME"), config)
 		client, err = factory.NewEJBCAClient()
 		if err != nil {
-			log.Fatal(err)
+			t.Fatal(err)
 		}
 		_, err = factory.NewESTClient(os.Getenv("EJBCA_USERNAME"), os.Getenv("EJBCA_PASSWORD"))
 		if err != nil {
-			log.Fatal(err)
+			t.Fatal(err)
 		}
 	}
 }

--- a/pkg/ejbca/est.go
+++ b/pkg/ejbca/est.go
@@ -16,6 +16,8 @@ func (e *ESTClient) CaCerts(alias string) ([]*x509.Certificate, error) {
 	endpoint := ""
 	if alias != "" {
 		endpoint = alias + "/"
+	} else if e.defaultESTAlias != "" {
+		endpoint = e.defaultESTAlias + "/"
 	}
 	endpoint += "cacerts"
 


### PR DESCRIPTION
Created new struct called CertificateData as shown below:
```go
type CertificateData struct {
	Certificate        *x509.Certificate
	SerialNumber       string
	CertificateChain   []*x509.Certificate
	PrivateKey         interface{}
	CertificateProfile string
	EndEntityProfile   string
}
```
This struct is returned by certificate methods that retrieve certificates from EJBCA in some capacity. Also created is a serialization method that imports certificates returned by EJBCA into Go standard x509 structures.